### PR TITLE
Add support for loading mod_spatialite on OSX

### DIFF
--- a/spatialite.go
+++ b/spatialite.go
@@ -14,6 +14,7 @@ type entrypoint struct {
 
 var LibNames = []entrypoint{
 	{"mod_spatialite", "sqlite3_modspatialite_init"},
+	{"mod_spatialite.dylib", "sqlite3_modspatialite_init"},
 	{"libspatialite.so", "sqlite3_modspatialite_init"},
 	{"libspatialite.so", "spatialite_init_ex"},
 }


### PR DESCRIPTION
I recently moved from linux to OSX and found that I needed to add the following line to get this lib working on OSX.

This applies to OSX when spatialite is installed via the `brew` package manager and is documented here:
https://github.com/Homebrew/homebrew-core/blob/master/Formula/libspatialite.rb#L49-L52